### PR TITLE
Binding polymer dependency to latest major

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "polymer-jsonp",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#0.4.1"
+    "polymer": "Polymer/polymer#^0.4.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "polymer-jsonp",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#master"
+    "polymer": "Polymer/polymer#0.4.1"
   }
 }


### PR DESCRIPTION
Ref [this issue](https://github.com/Polymer/polymer/issues/758), Polymer itself is now using caret notation for its own dependencies. This component should as well. 

Also included a gitignore file for good measure :+1: 
